### PR TITLE
Fixing ZeroDivisionError exception

### DIFF
--- a/getMemcachedInfo.py
+++ b/getMemcachedInfo.py
@@ -59,7 +59,10 @@ class MemcachedStatsReader(object):
                 continue
 	    index = parts[1]
 	    self._stats[index] = parts[2]
-        ratio = float (self._stats["get_hits"]) * 100 / float (self._stats["cmd_get"])
+        try:
+            ratio = float (self._stats["get_hits"]) * 100 / float (self._stats["cmd_get"])
+        except ZeroDivisionError:
+            ratio = 0.0
         self._stats["ratio"] = round (ratio, 2)
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
When testing with a brand new memcached instance, the script fails with a ZeroDivisionError exception.
